### PR TITLE
Fix: Add vercel.json for SPA client-side routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
• Add `vercel.json` with rewrite rules to support client-side routing
• Fixes 404 errors when directly navigating to routes like `/c-class-heroes` or `/bavap`

## Problem
When navigating directly to SPA routes (e.g., `https://dballsched.vercel.app/c-class-heroes`), Vercel returned a 404 because it looked for a file at that path instead of serving `index.html` for the React Router to handle.

## Solution
Added a `vercel.json` with a rewrite rule that directs all routes to `index.html`, allowing the client-side router to handle navigation.

## TODO list
- [x] Create vercel.json with rewrite configuration
- [x] Test deployment