### PR TITLE
feat: highlight current time block with ring and auto-scroll

### DIFF
--- a/src/components/BreakCard.jsx
+++ b/src/components/BreakCard.jsx
@@ -1,6 +1,6 @@
-export default function BreakCard() {
+export default function BreakCard({ isCurrent }) {
   return (
-    <div className="bg-gray-100 border-l-4 border-gray-400 rounded-lg p-3 shadow-sm">
+    <div className={`bg-gray-100 border-l-4 border-gray-400 rounded-lg p-3 ${isCurrent ? 'shadow-lg ring-2 ring-gray-400' : 'shadow-sm'}`}>
       <p className="text-gray-600 font-medium">Break</p>
     </div>
   );

--- a/src/components/GameCard.jsx
+++ b/src/components/GameCard.jsx
@@ -1,4 +1,4 @@
-export default function GameCard({ event, selectedPlayer, showPlaying, roster }) {
+export default function GameCard({ event, selectedPlayer, showPlaying, roster, isCurrent }) {
   const getPlayingPlayers = (sittingPlayers) => {
     const playingPlayers = roster.filter(player => !sittingPlayers.includes(player));
     return playingPlayers.join(", ") || "All";
@@ -24,7 +24,7 @@ export default function GameCard({ event, selectedPlayer, showPlaying, roster })
   const playingStatus = getPlayingStatus();
 
   return (
-    <div className="bg-blue-100 border-l-4 border-blue-500 rounded-lg p-3 shadow-sm">
+    <div className={`bg-blue-100 border-l-4 border-blue-500 rounded-lg p-3 ${isCurrent ? 'shadow-lg ring-2 ring-blue-400' : 'shadow-sm'}`}>
       <div className="flex justify-between items-start">
         <p className="text-blue-900 font-semibold">vs {event.opponent}</p>
         <span className="bg-blue-500 text-white text-xs px-2 py-1 rounded">Game</span>

--- a/src/components/RefCard.jsx
+++ b/src/components/RefCard.jsx
@@ -1,6 +1,6 @@
-export default function RefCard({ event }) {
+export default function RefCard({ event, isCurrent }) {
   return (
-    <div className="bg-orange-100 border-l-4 border-orange-500 rounded-lg p-3 shadow-sm">
+    <div className={`bg-orange-100 border-l-4 border-orange-500 rounded-lg p-3 ${isCurrent ? 'shadow-lg ring-2 ring-orange-400' : 'shadow-sm'}`}>
       <div className="flex justify-between items-start">
         <p className="text-orange-700 font-semibold">Court {event.court}</p>
         <span className="bg-orange-500 text-white text-xs px-2 py-1 rounded">Reffing</span>

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -29,40 +29,34 @@ export default function ScheduleTimeline({ events, selectedPlayer, showPlaying, 
     return eventMinutes < currentMinutes;
   };
 
-  useEffect(() => {
-    if (sortedEvents.length === 0) return;
-
-    const now = new Date();
-    const estTime = new Date(now.toLocaleString("en-US", { timeZone: "America/New_York" }));
-    const targetTime = new Date(estTime.getTime() - 60 * 60 * 1000); // 1 hour before
-    const targetMinutes = targetTime.getHours() * 60 + targetTime.getMinutes();
-
-    // Get first event time
-    const [firstHours, firstMins] = sortedEvents[0].time.split(":").map(Number);
-    const firstEventMinutes = firstHours * 60 + firstMins;
-
-    // Don't scroll if target time is before the first event
-    if (targetMinutes < firstEventMinutes) return;
-
-    let closestIndex = 0;
-    let closestDiff = Infinity;
-
-    sortedEvents.forEach((event, index) => {
+  const currentIndex = useMemo(() => {
+    // Find the first event that hasn't started yet
+    const nextEventIndex = sortedEvents.findIndex(event => {
       const [hours, minutes] = event.time.split(":").map(Number);
       const eventMinutes = hours * 60 + minutes;
-      const diff = Math.abs(eventMinutes - targetMinutes);
-
-      if (diff < closestDiff) {
-        closestDiff = diff;
-        closestIndex = index;
-      }
+      return eventMinutes > currentMinutes;
     });
 
-    const targetRef = itemRefs.current[closestIndex];
-    if (targetRef) {
-      targetRef.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (nextEventIndex === -1) {
+      // All events have started - the last one is current
+      return sortedEvents.length - 1;
+    } else if (nextEventIndex === 0) {
+      // No events have started yet - first one is next up
+      return 0;
+    } else {
+      // The event before the next one is the currently active one
+      return nextEventIndex - 1;
     }
-  }, [sortedEvents]);
+  }, [sortedEvents, currentMinutes]);
+
+  useEffect(() => {
+    if (sortedEvents.length === 0 || currentIndex < 0) return;
+
+    const targetRef = itemRefs.current[currentIndex];
+    if (targetRef) {
+      targetRef.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [sortedEvents, currentIndex]);
 
   return (
     <Timeline position="right">
@@ -70,7 +64,7 @@ export default function ScheduleTimeline({ events, selectedPlayer, showPlaying, 
         <TimelineItem
           key={index}
           ref={(el) => (itemRefs.current[index] = el)}
-          sx={{ opacity: isPast(event.time) ? 0.5 : 1 }}
+          sx={{ opacity: isPast(event.time) && index !== currentIndex ? 0.5 : 1 }}
         >
           <TimelineOppositeContent sx={{ flex: 'none', width: '45px', pl: 0, pr: 0.5, textAlign: 'left' }} className="text-sm font-bold">
             {event.time}
@@ -80,9 +74,9 @@ export default function ScheduleTimeline({ events, selectedPlayer, showPlaying, 
             {index < sortedEvents.length - 1 && <TimelineConnector />}
           </TimelineSeparator>
           <TimelineContent>
-            {event.type === "game" && <GameCard event={event} selectedPlayer={selectedPlayer} showPlaying={showPlaying} roster={roster} />}
-            {event.type === "ref" && <RefCard event={event} />}
-            {event.type === "break" && <BreakCard />}
+            {event.type === "game" && <GameCard event={event} selectedPlayer={selectedPlayer} showPlaying={showPlaying} roster={roster} isCurrent={index === currentIndex} />}
+            {event.type === "ref" && <RefCard event={event} isCurrent={index === currentIndex} />}
+            {event.type === "break" && <BreakCard isCurrent={index === currentIndex} />}
           </TimelineContent>
         </TimelineItem>
       ))}


### PR DESCRIPTION
## Summary
- Add visual emphasis (ring outline and larger shadow) to the currently active schedule block
- Current block stays at full opacity while past blocks are faded
- Auto-scroll to center the current block on page load

## TODO list
- [x] Add currentIndex calculation to determine active block
- [x] Pass isCurrent prop to card components
- [x] Apply ring-2 and shadow-lg styling for emphasis
- [x] Fix opacity logic to not fade the current block
- [x] Update auto-scroll to center on current block